### PR TITLE
remove markers from assert tests

### DIFF
--- a/test_simple_assert.py
+++ b/test_simple_assert.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import pytest
+import time
+
 from selenium import webdriver
 
 
 browser = webdriver.Firefox()
+browser.maximize_window()
 
 
 def test_assert_title_of_homepage():
@@ -12,15 +14,14 @@ def test_assert_title_of_homepage():
     assert browser.title == "Home - Send and Receive Automated Call and SMS Text Campaigns."
 
 
-@pytest.mark.xfail()
-def test_assert_presence_of_login_link():
+def test_assert_presence_of_login_button():
     browser.get("https://www.engagespark.com/")
     assert browser.find_element_by_link_text("login")
 
 
-@pytest.mark.xfail(reason="needs wait")
-def test_assert_login_page():
+def test_assert_availability_of_login_page():
     browser.get("https://www.engagespark.com/")
     browser.find_element_by_link_text("login").click()
+    time.sleep(10)
     assert browser.title == "engageSPARK - Sign In"
     assert browser.find_element_by_id("loginform")


### PR DESCRIPTION
To avoid confusion, markers will have to be tackled on the next module, not on this one. It's better to have this test module stick to `asserts`